### PR TITLE
Improve rental listings page styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Houston Rental Listings - April 2025</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        .property { border: 1px solid #ddd; margin: 10px 0; padding: 15px; border-radius: 5px; }
-        .price { font-size: 1.2em; color: #2c5282; font-weight: bold; }
+        body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.6; max-width: 1200px; margin: 0 auto; padding: 20px; }
+        .property { border: 1px solid #ddd; margin: 15px 0; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .price { font-size: 1.3em; color: #2c5282; font-weight: bold; margin: 10px 0; }
         .details { color: #4a5568; margin: 10px 0; }
-        .address { font-weight: bold; }
+        .address { font-weight: bold; font-size: 1.1em; }
+        .last-updated { color: #666; font-size: 0.9em; text-align: right; margin-top: 20px; }
+        h1 { color: #2d3748; margin-bottom: 30px; }
     </style>
 </head>
 <body>
@@ -105,5 +107,6 @@
             </div>
         </div>
     </div>
+    <div class="last-updated">Last updated: April 6, 2025</div>
 </body>
 </html>


### PR DESCRIPTION
This PR improves the rental listings page with:

- Enhanced visual styling with box shadows and better spacing
- Improved typography and readability
- Added last updated timestamp
- Centered content with max-width for better readability
- Improved color scheme

The page contains 10 current rental listings in Houston, TX, ranging from $1,455 to $2,388 per month.